### PR TITLE
refactor: improve resuability of release fetchers, add tests

### DIFF
--- a/pkg/releases/fetcher.go
+++ b/pkg/releases/fetcher.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Djamaile Rahamat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package releases
 
 import (

--- a/pkg/releases/fetcher.go
+++ b/pkg/releases/fetcher.go
@@ -1,0 +1,69 @@
+package releases
+
+import (
+	"fmt"
+	"github.com/gocolly/colly"
+	"net"
+	"net/http"
+	"os"
+	"path"
+	"time"
+)
+
+type elementMapper = func(element *colly.HTMLElement) Manga
+
+type ReleaseFetcher interface {
+	Fetch() ([]Manga, error)
+}
+
+type releaseFetcher struct {
+	http          *http.Transport
+	url           string
+	querySelector string
+	mapper        elementMapper
+}
+
+func (r releaseFetcher) Fetch() ([]Manga, error) {
+	var releases []Manga
+
+	collector := colly.NewCollector()
+	collector.WithTransport(r.http)
+
+	collector.OnHTML(r.querySelector, func(element *colly.HTMLElement) {
+		releases = append(releases, r.mapper(element))
+	})
+
+	collector.OnRequest(func(request *colly.Request) {
+		fmt.Println("Visiting", request.URL)
+	})
+
+	pwd, _ := os.Getwd()
+	filePath := "file://" + path.Join(pwd, r.url)
+	if err := collector.Visit(filePath); err != nil {
+		return nil, err
+	}
+
+	return releases, nil
+}
+
+func NewReleaseFetcher(querySelector string, url string, mapper elementMapper) ReleaseFetcher {
+	t := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+
+	return releaseFetcher{
+		http:          t,
+		querySelector: querySelector,
+		url:           url,
+		mapper:        mapper,
+	}
+}

--- a/pkg/releases/fetcher_test.go
+++ b/pkg/releases/fetcher_test.go
@@ -1,0 +1,90 @@
+package releases
+
+import (
+	"github.com/gocolly/colly"
+	"net"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func Test_releaseFetcher_Fetch(t *testing.T) {
+	transport := &http.Transport{
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+	transport.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+
+	type fields struct {
+		http          *http.Transport
+		url           string
+		querySelector string
+		mapper        elementMapper
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []Manga
+		wantErr bool
+	}{
+		{
+			name: "should fetch a single manga from test page",
+			fields: fields{
+				http:          transport,
+				url:           "testdata/test.html",
+				querySelector: ".test_div",
+				mapper: func(element *colly.HTMLElement) Manga {
+					temp := Manga{}
+					temp.Name = element.ChildText(".title")
+					temp.Image = element.ChildAttr(".item img", "src")
+					temp.Link = element.ChildAttr("a.link", "href")
+					temp.Liked = false
+					return temp
+				},
+			},
+			want: []Manga{
+				{
+					Name:  "Test title",
+					Image: "test.png",
+					Link:  "https://test.nl",
+					Liked: false,
+				},
+			},
+		},
+		{
+			name: "should return an error when fetching manga from a non-existing path",
+			fields: fields{
+				http: transport,
+				url:  "testdata/not_existing_page.html",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := releaseFetcher{
+				http:          tt.fields.http,
+				url:           tt.fields.url,
+				querySelector: tt.fields.querySelector,
+				mapper:        tt.fields.mapper,
+			}
+			got, err := r.Fetch()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Fetch() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Fetch() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/releases/fetcher_test.go
+++ b/pkg/releases/fetcher_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Djamaile Rahamat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package releases
 
 import (

--- a/pkg/releases/releases.go
+++ b/pkg/releases/releases.go
@@ -16,11 +16,6 @@ package releases
 
 import (
 	"fmt"
-	"net/http"
-	"os"
-	"path"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/gocolly/colly"
@@ -37,196 +32,124 @@ var location, _ = time.LoadLocation("UTC")
 var year, month, day = time.Now().In(location).Date()
 
 func CollectYenPressReleases() []Manga {
-	var allYenReleases []Manga
-
-	collector := colly.NewCollector()
-
-	t := &http.Transport{}
-	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
-
-	collector.WithTransport(t)
-
-	collector.OnHTML(".book-shelf-title-grid", func(element *colly.HTMLElement) {
+	url := toLocalPagesPath("yenpress")
+	releases, err := NewReleaseFetcher(".book-shelf-title-grid", url, func(element *colly.HTMLElement) Manga {
 		temp := Manga{}
 		temp.Name = element.ChildText(".book-detail h2")
 		temp.Image = element.ChildAttr("img", "src")
 		temp.Link = "https://yenpress.com" + element.ChildAttr(".book-detail-links a", "href")
-		allYenReleases = append(allYenReleases, temp)
-	})
+		return temp
+	}).Fetch()
 
-	collector.OnRequest(func(request *colly.Request) {
-		fmt.Println("Visiting", request.URL)
-	})
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 
-	pwd, _ := os.Getwd()
-	s := fmt.Sprintf("pages/yenpress-%d-%d-%d.html", int(year), int(month), int(day))
-	collector.Visit("file://" + path.Join(pwd, s))
-
-	return allYenReleases
+	return releases
 }
 
 func CollectSevenSeasReleases() []Manga {
-	var allSevenSeasReleases []Manga
-
-	t := &http.Transport{}
-	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
-
-	collector := colly.NewCollector()
-	collector.WithTransport(t)
-
-	collector.OnHTML("div[style='float: left; margin: 0 3px 10px 6px; width: 134px; height: 189px; background: #CECECE;']", func(element *colly.HTMLElement) {
+	url := toLocalPagesPath("sevenseas")
+	releases, err := NewReleaseFetcher("div[style='float: left; margin: 0 3px 10px 6px; width: 134px; height: 189px; background: #CECECE;']", url, func(element *colly.HTMLElement) Manga {
 		temp := Manga{}
 		temp.Name = element.ChildAttr("a", "title")
 		temp.Image = element.ChildAttr("img", "src")
 		temp.Link = element.ChildAttr("a", "href")
-		allSevenSeasReleases = append(allSevenSeasReleases, temp)
-	})
+		return temp
+	}).Fetch()
 
-	collector.OnRequest(func(request *colly.Request) {
-		fmt.Println("Visiting", request.URL.String())
-	})
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 
-	pwd, _ := os.Getwd()
-	s := fmt.Sprintf("pages/sevenseas-%d-%d-%d.html", int(year), int(month), int(day))
-	collector.Visit("file://" + path.Join(pwd, s))
-
-	return allSevenSeasReleases
+	return releases
 }
 
 func CollectDarkHorseReleases() []Manga {
-	var allDarkHorseReleases []Manga
-	year, month, _ := time.Now().Date()
-
-	t := &http.Transport{}
-	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
-
-	collector := colly.NewCollector()
-	collector.WithTransport(t)
-
-	collector.OnHTML(".list_item", func(element *colly.HTMLElement) {
+	url := toLocalPagesPath("darkhorse")
+	releases, err := NewReleaseFetcher(".list_item", url, func(element *colly.HTMLElement) Manga {
 		temp := Manga{}
 		temp.Name = element.ChildText("a.product_link")
 		temp.Image = element.ChildAttr("a.product_link img", "src")
 		temp.Link = element.ChildAttr("a.product_link", "href")
-		allDarkHorseReleases = append(allDarkHorseReleases, temp)
-	})
+		return temp
+	}).Fetch()
 
-	collector.OnRequest(func(request *colly.Request) {
-		fmt.Println("Visiting", request.URL.String())
-	})
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 
-	pwd, _ := os.Getwd()
-	s := fmt.Sprintf("pages/darkhorse-%d-%d-%d.html", int(year), int(month), int(day))
-	collector.Visit("file://" + path.Join(pwd, s))
-
-	return allDarkHorseReleases
+	return releases
 }
 
 func CollectKodanshaReleases() []Manga {
-	var allKodanshaReleases []Manga
-	_, month, _ := time.Now().Date()
+	url := toLocalPagesPath("kodansha")
+	releases, err := NewReleaseFetcher("div.card.book-card-small", url, func(element *colly.HTMLElement) Manga {
+		temp := Manga{}
+		temp.Name = element.ChildText(".card__link")
+		temp.Image = element.ChildAttr(".l-frame.product-image img", "src")
+		temp.Link = element.ChildAttr("a.card__link", "href")
+		return temp
+	}).Fetch()
 
-	t := &http.Transport{}
-	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 
-	collector := colly.NewCollector()
-	collector.WithTransport(t)
-
-	collector.OnHTML(".calendar__day", func(element *colly.HTMLElement) {
-		releaseDate := element.ChildText("h3.title.title--discovery")
-		releaseDate = strings.Split(releaseDate, "/")[0]
-
-		monthOfRelease, err := strconv.Atoi(releaseDate)
-		if err != nil {
-			fmt.Print("could not parse date")
-			return
-		}
-
-		if monthOfRelease != int(month) {
-			return
-		}
-
-		element.ForEach("div.card.book-card-small", func(_ int, el *colly.HTMLElement) {
-			temp := Manga{}
-			temp.Name = el.ChildText(".card__link")
-			temp.Image = el.ChildAttr(".l-frame.product-image img", "src")
-			temp.Link = el.ChildAttr("a.card__link", "href")
-			allKodanshaReleases = append(allKodanshaReleases, temp)
-		})
-	})
-
-	collector.OnRequest(func(request *colly.Request) {
-		fmt.Println("Visiting", request.URL.String())
-	})
-
-	pwd, _ := os.Getwd()
-	s := fmt.Sprintf("pages/kodansha-%d-%d-%d.html", int(year), int(month), int(day))
-	collector.Visit("file://" + path.Join(pwd, s))
-
-	return allKodanshaReleases
+	return releases
 }
 
 func CollectVizReleases() []Manga {
-	var allVizReleases []Manga
-
-	t := &http.Transport{}
-	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
-
-	collector := colly.NewCollector()
-	collector.WithTransport(t)
-
-	collector.OnHTML(".manga-books article", func(element *colly.HTMLElement) {
+	url := toLocalPagesPath("viz")
+	releases, err := NewReleaseFetcher(".manga-books article", url, func(element *colly.HTMLElement) Manga {
 		temp := Manga{}
 		temp.Name = element.ChildText(".color-off-black")
 		temp.Image = element.ChildAttr("a.product-thumb img", "data-original")
 		temp.Link = "https://viz.com" + element.ChildAttr("a.product-thumb", "href")
 		temp.Liked = false
-		allVizReleases = append(allVizReleases, temp)
-	})
+		return temp
+	}).Fetch()
 
-	collector.OnRequest(func(request *colly.Request) {
-		fmt.Println("Visiting", request.URL.String())
-	})
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 
-	pwd, _ := os.Getwd()
-	s := fmt.Sprintf("pages/viz-%d-%d-%d.html", int(year), int(month), int(day))
-	collector.Visit("file://" + path.Join(pwd, s))
-
-	return allVizReleases
+	return releases
 }
 
 func CollectTokyoPopReleases() []Manga {
-	var allTokyoPopReleases []Manga
-	_, month, _ := time.Now().Date()
-
-	t := &http.Transport{}
-	t.RegisterProtocol("file", http.NewFileTransport(http.Dir("/")))
-
-	collector := colly.NewCollector()
-	collector.WithTransport(t)
-
-	collector.OnHTML(".release-month", func(element *colly.HTMLElement) {
-		fmt.Println("hallo")
+	url := toLocalPagesPath("tokyopop")
+	releases, err := NewReleaseFetcher(".release-month", url, func(element *colly.HTMLElement) Manga {
 		monthOfRelease := element.ChildText(".release-month-label")
 		fmt.Println(monthOfRelease, month.String())
 		if monthOfRelease != month.String() {
-			return
+			return Manga{}
 		}
 
 		temp := Manga{}
 		temp.Name = element.ChildText(".rs-item-title")
 		temp.Image = element.ChildAttr(".rs-item-image", "data-src")
 		temp.Link = "bed"
-		allTokyoPopReleases = append(allTokyoPopReleases, temp)
-	})
+		return temp
+	}).Fetch()
 
-	collector.OnRequest(func(request *colly.Request) {
-		fmt.Println("Visiting", request.URL.String())
-	})
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
 
-	pwd, _ := os.Getwd()
-	s := fmt.Sprintf("pages/tokyopop-%d-%d-%d.html", int(year), int(month), int(day))
-	collector.Visit("file://" + path.Join(pwd, s))
+	return releases
+}
 
-	return allTokyoPopReleases
+func toLocalPagesPath(name string) string {
+	return toPagesPath("pages", name)
+}
+
+func toPagesPath(rootDir string, name string) string {
+	return fmt.Sprintf("%s/%s-%d-%d-%d.html", rootDir, name, int(year), int(month), int(day))
 }

--- a/pkg/releases/testdata/test.html
+++ b/pkg/releases/testdata/test.html
@@ -1,0 +1,11 @@
+<html>
+<div class="test_div">
+    <h1 class="title">
+        Test title
+    </h1>
+    <div class="item">
+        <img src="test.png"/>
+    </div>
+    <a class="link" href="https://test.nl">Link</a>
+</div>
+</html>


### PR DESCRIPTION
This is an attempt at restructuring the code to make the fetching logic more reusable. `Fetch()` now does the main logic for fetching a page whilst each function calling it specifies its own `elementMapper` function which is executed on each matched element through the `querySelector`

Resolves #5 